### PR TITLE
Make the split work for 5.1.1.

### DIFF
--- a/postgres-dump-splitter/src/main/java/es/keensoft/db/PostgresSplitter.java
+++ b/postgres-dump-splitter/src/main/java/es/keensoft/db/PostgresSplitter.java
@@ -35,6 +35,7 @@ public class PostgresSplitter implements CommandLineRunner {
 	
 	private static final String ALTER_TABLE_START = "ALTER TABLE";
 	private static final String CREATE_INDEX_START = "CREATE INDEX";
+	private static final String CREATE_UNIQUE_INDEX_START = "CREATE UNIQUE INDEX";
 	private static final String CREATE_SEQUENCE = "CREATE SEQUENCE";
 	private static final String CREATE_TABLE ="CREATE TABLE";
 	
@@ -96,7 +97,7 @@ public class PostgresSplitter implements CommandLineRunner {
 		while ((line = br.readLine()) != null) {
 			
 			if (!insideIndexConstraint) {
-				if (line.startsWith(ALTER_TABLE_START) || line.startsWith(CREATE_INDEX_START)) {
+				if (line.startsWith(ALTER_TABLE_START) || line.startsWith(CREATE_INDEX_START) || line.startsWith(CREATE_UNIQUE_INDEX_START)) {
 				    bw.write(line + System.lineSeparator());
 				    insideIndexConstraint = !line.endsWith(DDL_SENTENCE_END);
 					if (!insideIndexConstraint) bw.write(System.lineSeparator());

--- a/postgres-dump-splitter/src/main/java/es/keensoft/db/PostgresSplitter.java
+++ b/postgres-dump-splitter/src/main/java/es/keensoft/db/PostgresSplitter.java
@@ -154,11 +154,17 @@ public class PostgresSplitter implements CommandLineRunner {
 		bw = new BufferedWriter(new FileWriter(updateSequences));
 		for (String sequence : sequencesList) {
 			String sql = "";
-			if (sequence.equals("alf_activity_post_seq")) {
+			if (sequence.endsWith("alf_activity_post_seq")) {
 				sql = "select setval('" + sequence + "', " +
 				        "(select max(sequence_id)+1 from " + sequence.substring(0, sequence.length() - 4) + "), false);";
+			} else if (sequence.endsWith("act_evt_log_log_nr__seq")) {
+				sql = "select setval('" + sequence + "', " +
+						"(select max(log_nr_)+1 from " + sequence.substring(0, sequence.length() - 12) + "), false);";
+			} else if (sequence.endsWith("alf_content_url_enc_seq")) {
+				sql = "select setval('" + sequence + "', " +
+						"(select max(id)+1 from " + sequence.substring(0, sequence.length() - 4) + "ryption), false);";
 			}
-			else if (!sequence.equals("hibernate_sequence")) {
+			else if (!sequence.endsWith("hibernate_sequence")) {
 				sql = "select setval('" + sequence + "', " +
 			        "(select max(id)+1 from " + sequence.substring(0, sequence.length() - 4) + "), false);";
 			}


### PR DESCRIPTION
I had problems because all of my tables and sequences started with "public." . Also, in newer versions of Alfresco (5.1.1) other sequences were not following the same name convention.